### PR TITLE
Fix isinstance union bug

### DIFF
--- a/private_gpt/open_ai/openai_models.py
+++ b/private_gpt/open_ai/openai_models.py
@@ -114,7 +114,7 @@ def to_openai_sse_stream(
     sources: list[Chunk] | None = None,
 ) -> Iterator[str]:
     for response in response_generator:
-        if isinstance(response, CompletionResponse | ChatResponse):
+        if isinstance(response, (CompletionResponse, ChatResponse)):
             yield f"data: {OpenAICompletion.json_from_delta(text=response.delta)}\n\n"
         else:
             yield f"data: {OpenAICompletion.json_from_delta(text=response, sources=sources)}\n\n"


### PR DESCRIPTION
## Summary
- fix isinstance usage for union types in to_openai_sse_stream

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'injector')*

------
https://chatgpt.com/codex/tasks/task_e_683fcc7ad6b08322ba1bb75043bb823b