### PR TITLE
Add WSL setup and start scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,23 @@ Stay tuned to our [releases](https://github.com/zylon-ai/private-gpt/releases) t
 Full documentation on installation, dependencies, configuration, running the server, deployment options,
 ingesting local documents, API details and UI features can be found here: https://docs.privategpt.dev/
 
+### Quick setup for WSL
+For a first time installation on a Windows Subsystem for Linux (WSL) environment you can use the provided
+`setup_wsl.sh` script. It installs all Python dependencies and downloads the models so the application can
+run completely offline:
+
+```bash
+./setup_wsl.sh
+```
+
+Once the setup has finished you can start the API and the web UI with:
+
+```bash
+./run_private_gpt.sh
+```
+
+Windows users can run the equivalent `setup_wsl.bat` and `run_private_gpt.bat` scripts.
+
 ## 🧩 Architecture
 Conceptually, PrivateGPT is an API that wraps a RAG pipeline and exposes its
 primitives.

--- a/run_private_gpt.bat
+++ b/run_private_gpt.bat
@@ -1,0 +1,3 @@
+@echo off
+set PGPT_PROFILES=local
+poetry run python -m private_gpt

--- a/run_private_gpt.sh
+++ b/run_private_gpt.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+# Default profile is local unless specified
+export PGPT_PROFILES="${PGPT_PROFILES:-local}"
+
+poetry run python -m private_gpt

--- a/setup_wsl.bat
+++ b/setup_wsl.bat
@@ -1,0 +1,4 @@
+@echo off
+poetry install --no-interaction --extras ui
+poetry run python scripts/setup
+ECHO Setup completed

--- a/setup_wsl.sh
+++ b/setup_wsl.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+# Install Python dependencies and UI extras
+poetry install --no-interaction --extras ui
+
+# Download models for offline use
+poetry run python scripts/setup
+
+echo "Setup completed"


### PR DESCRIPTION
## Summary
- document quick setup using helper scripts
- add helper scripts to install dependencies and download models
- add helper scripts to launch the server

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_683fd29d10b88322bcbc025b6660272d